### PR TITLE
Add single 'y' year format

### DIFF
--- a/Resources/index.html
+++ b/Resources/index.html
@@ -125,14 +125,19 @@
             <td colspan="3">Year</td>
           </tr>
           <tr>
+            <td>y</td>
+            <td>2008</td>
+            <td>Year, no padding</td>
+          </tr>
+          <tr>
             <td>yy</td>
             <td>08</td>
-            <td>2-digit year</td>
+            <td>Year, two digits (padding with a zero if necessary)</td>
           </tr>
           <tr>
             <td>yyyy</td>
             <td>2008</td>
-            <td>4-digit year</td>
+            <td>Year, minimum of four digits (padding with zeros if necessary)</td>
           </tr>
           <tr class="separator">
             <td colspan="3">Quarter</td>


### PR DESCRIPTION
Hi there,

Firstly, great site! Really useful.

Secondly, I've added another year format using a single `y` which displays the year with no padding. See [UTS #35](http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns) for further information.