### PR TITLE
Added the option to change the locale

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,5 +5,5 @@ let package = Package(
  dependencies: [
    .Package(url: "https://github.com/nestproject/Frank.git", majorVersion: 0, minor: 2),
    .Package(url: "https://github.com/kylef/Stencil", majorVersion: 0),
-   .Package(url: "https://github.com/czechboy0/Jay.git", majorVersion: 0)
+   .Package(url: "https://github.com/czechboy0/Jay.git", majorVersion: 0, minor: 3)
  ])

--- a/Resources/index.html
+++ b/Resources/index.html
@@ -19,11 +19,13 @@
     var dateInput = $("#date").val();
     var date = moment(dateInput);
     var format = $("#format").val();
+    var locale = $("#locale option:selected").val();
 
     var params = $.param({
       date: encodeURIComponent(date.format()), // need to properly escape the +
       format: format,
-      time_zone_offset: (new Date().getTimezoneOffset() / -60)
+      time_zone_offset: (new Date().getTimezoneOffset() / -60),
+      locale: locale
     });
 
     if (dateInput.length > 0 && format.length > 0) {
@@ -67,6 +69,10 @@
     $(".try input[type='text']").change(function() {
       formatDate();
     })
+
+    $('#locale').change(function() {
+      formatDate()
+    });
   });
   </script>
 </head>
@@ -89,6 +95,15 @@
         <div class="field">
           <label>Format String</label>
           <input id="format" name="format" type="text" value="MMM yyyy">
+        </div>
+
+        <div class="field-locale">
+          <label>Locale</label>
+          <select name="locales" id="locale">
+            {% for locale in locales %}
+            <option {% if locale.default %}selected{% endif %} value="{{ locale.id }}">{{ locale.id }}</option>
+            {% endfor %}
+          </select>
         </div>
       </form>
 

--- a/Resources/styles.css
+++ b/Resources/styles.css
@@ -66,7 +66,13 @@ header h2 {
 
 .try .field {
   float: left;
-  width: 48%;
+  width: 40%;
+  position: relative;
+}
+
+.try .field-locale {
+  float: left;
+  width: 10%;
   position: relative;
 }
 


### PR DESCRIPTION
Hi Ben!
I’ve added the option to change the locale so we can check online how the formatting will look in other languages.
Here is screenshot of how it looks using the locale for Catalan.

<img width="1001" alt="screen" src="https://cloud.githubusercontent.com/assets/750912/14830502/f15f32e6-0be8-11e6-843e-650a1ab1fb3f.png">

I was thinking to use (or add an option) `setLocalizedDateFormatFromTemplate` which is really useful but it’s not available yet on the Swift version that the project is using. There are also some bugs on the date formatting of that version, for example on the screenshot you should see “d’abril” as it does in Apple NSFoundation. Maybe it’s already fixed in a newer release, I will try to take a look. 

You will see that I had to specify the minor version of Jay, without it installing the dependencies from scratch didn’t work as SPM was using a newer version. 

A part from that, any recommendation with the CSS is welcomed. I kept the default locale as `en_US_POSIX`.

Thanks for the website ;)