### PR TITLE
Update day of week examples

### DIFF
--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -141,18 +141,23 @@
         </tr>
         <tr>
           <td>E</td>
-          <td>Tues</td>
-          <td>The day of week in the month</td>
+          <td>Tue</td>
+          <td>The abbreviation for the day of the week</td>
         </tr>
         <tr>
           <td>EEEE</td>
           <td>Tuesday</td>
-          <td>The full name of the day</td>
+          <td>The wide name of the day of the week</td>
         </tr>
         <tr>
           <td>EEEEE</td>
           <td>T</td>
           <td>The narrow day of week</td>
+        </tr>
+        <tr>
+          <td>EEEEEE</td>
+          <td>Tu</td>
+          <td>The short day of week</td>
         </tr>
         <tr class="separator">
           <td colspan="3">Hour</td>


### PR DESCRIPTION
The Unicode LDML documentation used to call for the weekday abbreviation to sometimes be more than three characters (such as `Tuesday` being represented as `Tues`). The documentation was corrected in 2015 to show using a three character abbreviation (in this example, `Tue`). (This change was made in the official docs in https://github.com/unicode-org/cldr/commit/ca91e67020308739ba9aafe262dee7435ec08d16).

While I was here, I also added the missing "short" form which is two characters.