### PR TITLE
Improve the example for milliseconds.

### DIFF
--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -216,7 +216,7 @@
         </tr>
         <tr>
           <td>SSS</td>
-          <td>1234</td>
+          <td>123</td>
           <td>The milliseconds.</td>
         </tr>
         <tr class="separator">


### PR DESCRIPTION
For the milliseconds the format is SSS and the example is "1234". There's only three digits in the milliseconds, so a better example would be "123". 