### PR TITLE
Info + Bulk Format APIs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,169 +1,212 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "async-http-client",
-        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
-        "state": {
-          "branch": null,
-          "revision": "70826d038d5bdc3142a386b735792d87ef7a5dfc",
-          "version": "1.8.1"
-        }
-      },
-      {
-        "package": "async-kit",
-        "repositoryURL": "https://github.com/vapor/async-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "3b1e7e9069a62295151c6c1609050cd38a0a7af5",
-          "version": "1.11.0"
-        }
-      },
-      {
-        "package": "console-kit",
-        "repositoryURL": "https://github.com/vapor/console-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "75ea3b627d88221440b878e5dfccc73fd06842ed",
-          "version": "4.2.7"
-        }
-      },
-      {
-        "package": "leaf",
-        "repositoryURL": "https://github.com/vapor/leaf.git",
-        "state": {
-          "branch": null,
-          "revision": "ffff1a882ab880e2c4f919a82cd60518912e6499",
-          "version": "4.1.4"
-        }
-      },
-      {
-        "package": "leaf-kit",
-        "repositoryURL": "https://github.com/vapor/leaf-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "983fcbe89e7153c4d5870bdc76bf57a56817225f",
-          "version": "1.4.0"
-        }
-      },
-      {
-        "package": "multipart-kit",
-        "repositoryURL": "https://github.com/vapor/multipart-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "2dd9368a3c9580792b77c7ef364f3735909d9996",
-          "version": "4.5.1"
-        }
-      },
-      {
-        "package": "routing-kit",
-        "repositoryURL": "https://github.com/vapor/routing-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "5603b81ceb744b8318feab1e60943704977a866b",
-          "version": "4.3.1"
-        }
-      },
-      {
-        "package": "swift-backtrace",
-        "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
-        "state": {
-          "branch": null,
-          "revision": "d3e04a9d4b3833363fb6192065b763310b156d54",
-          "version": "1.3.1"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "9c53b7a758bb849a7df1bd2314395f5f0c14306f",
-          "version": "2.0.3"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
-        }
-      },
-      {
-        "package": "swift-metrics",
-        "repositoryURL": "https://github.com/apple/swift-metrics.git",
-        "state": {
-          "branch": null,
-          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
-          "version": "2.2.0"
-        }
-      },
-      {
-        "package": "swift-nio",
-        "repositoryURL": "https://github.com/apple/swift-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "213eb6887e526e0dfac526a2eae559a1893ebbac",
-          "version": "2.36.0"
-        }
-      },
-      {
-        "package": "swift-nio-extras",
-        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
-        "state": {
-          "branch": null,
-          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-          "version": "1.10.2"
-        }
-      },
-      {
-        "package": "swift-nio-http2",
-        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
-        "state": {
-          "branch": null,
-          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
-          "version": "1.19.1"
-        }
-      },
-      {
-        "package": "swift-nio-ssl",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
-        "state": {
-          "branch": null,
-          "revision": "2b329e37e9dd34fb382655181a680261d58cbbf1",
-          "version": "2.17.1"
-        }
-      },
-      {
-        "package": "swift-nio-transport-services",
-        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
-        "state": {
-          "branch": null,
-          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
-          "version": "1.11.3"
-        }
-      },
-      {
-        "package": "vapor",
-        "repositoryURL": "https://github.com/vapor/vapor.git",
-        "state": {
-          "branch": null,
-          "revision": "34bf1b303623de04801d2b9bef5b2ed48b3e9319",
-          "version": "4.54.0"
-        }
-      },
-      {
-        "package": "websocket-kit",
-        "repositoryURL": "https://github.com/vapor/websocket-kit.git",
-        "state": {
-          "branch": null,
-          "revision": "ff8fbce837ef01a93d49c6fb49a72be0f150dac7",
-          "version": "2.3.0"
-        }
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "291438696abdd48d2a83b52465c176efbd94512b",
+        "version" : "1.20.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "async-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/async-kit.git",
+      "state" : {
+        "revision" : "7ece208cd401687641c88367a00e3ea2b04311f1",
+        "version" : "1.19.0"
+      }
+    },
+    {
+      "identity" : "console-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/console-kit.git",
+      "state" : {
+        "revision" : "a31f44ebfbd15a2cc0fda705279676773ac16355",
+        "version" : "4.14.1"
+      }
+    },
+    {
+      "identity" : "leaf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/leaf.git",
+      "state" : {
+        "revision" : "0be8765af9991823c854d97faa4a97db1cfa2643",
+        "version" : "4.3.0"
+      }
+    },
+    {
+      "identity" : "leaf-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/leaf-kit.git",
+      "state" : {
+        "revision" : "547a1340b3a063ca738be4351660f59179c8dc34",
+        "version" : "1.10.3"
+      }
+    },
+    {
+      "identity" : "multipart-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/multipart-kit.git",
+      "state" : {
+        "revision" : "12ee56f25bd3fc4c2d09c2aa16e69de61dc786e8",
+        "version" : "4.6.0"
+      }
+    },
+    {
+      "identity" : "routing-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/routing-kit.git",
+      "state" : {
+        "revision" : "2a92a7eac411a82fb3a03731be5e76773ebe1b3e",
+        "version" : "4.9.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "cc76b894169a3c86b71bac10c78a4db6beb7a9ad",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "12358d55a3824bd5fed310b999ea8cf83a9a1a65",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "971ba26378ab69c43737ee7ba967a896cb74c0d1",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "635b2589494c97e48c62514bc8b37ced762e0a62",
+        "version" : "2.63.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "363da63c1966405764f380c627409b2f9d9e710b",
+        "version" : "1.21.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "0904bf0feb5122b7e5c3f15db7df0eabe623dd87",
+        "version" : "1.30.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "7c381eb6083542b124a6c18fae742f55001dc2b5",
+        "version" : "2.26.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "6cbe0ed2b394f21ab0d46b9f0c50c6be964968ce",
+        "version" : "1.20.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "025bcb1165deab2e20d4eaba79967ce73013f496",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "vapor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/vapor.git",
+      "state" : {
+        "revision" : "3a7da193a2937472b252b8db210897e7abf37b47",
+        "version" : "4.92.4"
+      }
+    },
+    {
+      "identity" : "websocket-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/websocket-kit.git",
+      "state" : {
+        "revision" : "53fe0639a98903858d0196b699720decb42aee7b",
+        "version" : "2.14.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Sources/App/Controllers/FormatAPIController.swift
+++ b/Sources/App/Controllers/FormatAPIController.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Vapor
+
+class FormatAPIController: RouteCollection {
+    
+    private let calendars = [
+        "gregorian": Calendar(identifier: .gregorian),
+        "buddhist": Calendar(identifier: .buddhist),
+        "chinese": Calendar(identifier: .chinese),
+        "coptic": Calendar(identifier: .coptic),
+        "ethiopicAmeteMihret": Calendar(identifier: .ethiopicAmeteMihret),
+        "ethiopicAmeteAlem": Calendar(identifier: .ethiopicAmeteAlem),
+        "hebrew": Calendar(identifier: .hebrew),
+        "iso8601": Calendar(identifier: .iso8601),
+        "indian": Calendar(identifier: .indian),
+        "islamic": Calendar(identifier: .islamic),
+        "islamicCivil": Calendar(identifier: .islamicCivil),
+        "japanese": Calendar(identifier: .japanese),
+        "persian": Calendar(identifier: .persian),
+        "republicOfChina": Calendar(identifier: .republicOfChina),
+        "islamicTabular": Calendar(identifier: .islamicTabular),
+        "islamicUmmAlQura": Calendar(identifier: .islamicUmmAlQura)
+    ]
+    
+    func boot(routes: RoutesBuilder) throws {
+        routes.post("format.json", use: formatJSON)
+    }
+    
+    func formatJSON(_ req: Request) async throws -> [FormatResponse] {
+        let requests = try req.content.decode([FormatRequest].self)
+        return try requests.map(processRequest)
+    }
+    
+    private func processRequest(_ request: FormatRequest) throws -> FormatResponse {
+        let locale: Locale
+        let calendar: Calendar
+        let calendarID: String
+        let timeZone: TimeZone
+        
+        if let localeID = request.locale {
+            let loweredLocaledID = localeID.lowercased()
+            guard let actualLocaleID = Locale.availableIdentifiers.first(where: { $0.lowercased() == loweredLocaledID }) else {
+                throw Abort(.badRequest, reason: "Unknown locale: '\(localeID)'")
+            }
+            locale = Locale(identifier: actualLocaleID)
+        } else {
+            locale = Locale(identifier: "en_US_POSIX")
+        }
+        
+        if let tzID = request.timeZone {
+            let loweredTZID = tzID.lowercased()
+            guard let actualTZID = TimeZone.knownTimeZoneIdentifiers.first(where: { $0.lowercased() == loweredTZID }) else {
+                throw Abort(.badRequest, reason: "Unknown time zone: '\(tzID)'")
+            }
+            timeZone = TimeZone(identifier: actualTZID)!
+        } else {
+            if #available(macOS 13, *) {
+                if let tz = locale.timeZone {
+                    timeZone = tz
+                } else {
+                    timeZone = TimeZone(secondsFromGMT: 0)!
+                }
+            } else {
+                timeZone = TimeZone(secondsFromGMT: 0)!
+            }
+        }
+        
+        if let calID = request.calendar {
+            guard let c = self.calendars[calID] else {
+                throw Abort(.badRequest, reason: "Unknown calendar: '\(calID)'")
+            }
+            calendar = c
+            calendarID = calID
+        } else {
+            calendar = locale.calendar
+            calendarID = "\(calendar.identifier)"
+        }
+        
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeZone = timeZone
+        formatter.locale = locale
+        
+        switch request.format {
+            case .date(let date):
+                formatter.dateStyle = date.dateFormatterStyle
+                formatter.timeStyle = .none
+            case .time(let time):
+                formatter.dateStyle = .none
+                formatter.timeStyle = time.dateFormatterStyle
+            case .dateAndTime(let date, let time):
+                formatter.dateStyle = date.dateFormatterStyle
+                formatter.timeStyle = time.dateFormatterStyle
+            case .template(let string):
+                formatter.dateFormat = DateFormatter.dateFormat(fromTemplate: string, options: 0, locale: locale)
+            case .raw(let string):
+                formatter.dateFormat = string
+        }
+        
+        let date: Date
+        if let timestamp = request.timestamp {
+            date = Date(timeIntervalSince1970: timestamp)
+        } else {
+            date = Date()
+        }
+        
+        let formatted = formatter.string(from: date)
+        
+        return FormatResponse(id: request.id,
+                              calendar: calendarID,
+                              timeZone: timeZone.identifier,
+                              locale: locale.identifier,
+                              timestamp: date.timeIntervalSince1970,
+                              format: formatter.dateFormat,
+                              value: formatted)
+    }
+}
+
+struct FormatRequest: Content {
+    let id: String?
+    let calendar: String?
+    let timeZone: String?
+    let locale: String?
+    let timestamp: Double?
+    let format: Format
+    
+    enum Style: String, Codable {
+        case full
+        case long
+        case medium
+        case short
+        
+        var dateFormatterStyle: DateFormatter.Style {
+            switch self {
+                case .full: return .full
+                case .long: return .long
+                case .medium: return .medium
+                case .short: return .short
+            }
+        }
+    }
+    
+    enum Format: Codable {
+        
+        enum CodingKeys: CodingKey {
+            case date
+            case time
+            case template
+            case raw
+        }
+        
+        case date(Style)
+        case time(Style)
+        case dateAndTime(Style, Style)
+        case template(String)
+        case raw(String)
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: FormatRequest.Format.CodingKeys.self)
+            let allKeys = container.allKeys
+            
+            if allKeys == [.date] {
+                self = .date(try container.decode(Style.self, forKey: .date))
+            } else if allKeys == [.date, .time] || allKeys == [.time, .date] {
+                self = .dateAndTime(try container.decode(Style.self, forKey: .date),
+                                    try container.decode(Style.self, forKey: .time))
+            } else if allKeys == [.time] {
+                self = .time(try container.decode(Style.self, forKey: .time))
+            } else if allKeys == [.template] {
+                self = .template(try container.decode(String.self, forKey: .template))
+            } else if allKeys == [.raw] {
+                self = .raw(try container.decode(String.self, forKey: .raw))
+            } else {
+                let keyNames = allKeys.map(\.stringValue)
+                throw Abort(.badRequest, reason: "Invalid format options: '\(keyNames)'")
+            }
+        }
+        
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+                case .date(let style):
+                    try container.encode(style, forKey: .date)
+                case .time(let style):
+                    try container.encode(style, forKey: .time)
+                case .dateAndTime(let d, let t):
+                    try container.encode(d, forKey: .date)
+                    try container.encode(t, forKey: .time)
+                case .template(let t):
+                    try container.encode(t, forKey: .template)
+                case .raw(let r):
+                    try container.encode(r, forKey: .raw)
+            }
+        }
+    }
+    
+}
+
+struct FormatResponse: Content {
+    let id: String?
+    let calendar: String
+    let timeZone: String
+    let locale: String
+    let timestamp: Double
+    let format: String
+    let value: String
+}

--- a/Sources/App/Controllers/FormatAPIController.swift
+++ b/Sources/App/Controllers/FormatAPIController.swift
@@ -23,7 +23,15 @@ class FormatAPIController: RouteCollection {
     ]
     
     func boot(routes: RoutesBuilder) throws {
+        routes.get("info.json", use: infoJSON)
         routes.post("format.json", use: formatJSON)
+    }
+    
+    func infoJSON(_ req: Request) async throws -> InfoResponse {
+        return InfoResponse(calendars: self.calendars.keys.sorted(by: <),
+                            locales: Locale.availableIdentifiers.sorted(by: <),
+                            timeZones: TimeZone.knownTimeZoneIdentifiers.sorted(by: <),
+                            timeZoneDataVersion: TimeZone.timeZoneDataVersion)
     }
     
     func formatJSON(_ req: Request) async throws -> [FormatResponse] {
@@ -204,4 +212,11 @@ struct FormatResponse: Content {
     let timestamp: Double
     let format: String
     let value: String
+}
+
+struct InfoResponse: Content {
+    let calendars: Array<String>
+    let locales: Array<String>
+    let timeZones: Array<String>
+    let timeZoneDataVersion: String
 }

--- a/Sources/App/Controllers/FormatAPIController.swift
+++ b/Sources/App/Controllers/FormatAPIController.swift
@@ -3,23 +3,25 @@ import Vapor
 
 class FormatAPIController: RouteCollection {
     
+    // These identifiers match the CLDR calendar identifiers
+    // https://github.com/unicode-org/icu/blob/main/icu4c/source/i18n/ucal.cpp#L694
     private let calendars = [
-        "gregorian": Calendar(identifier: .gregorian),
-        "buddhist": Calendar(identifier: .buddhist),
-        "chinese": Calendar(identifier: .chinese),
-        "coptic": Calendar(identifier: .coptic),
-        "ethiopicAmeteMihret": Calendar(identifier: .ethiopicAmeteMihret),
-        "ethiopicAmeteAlem": Calendar(identifier: .ethiopicAmeteAlem),
-        "hebrew": Calendar(identifier: .hebrew),
-        "iso8601": Calendar(identifier: .iso8601),
-        "indian": Calendar(identifier: .indian),
-        "islamic": Calendar(identifier: .islamic),
-        "islamicCivil": Calendar(identifier: .islamicCivil),
-        "japanese": Calendar(identifier: .japanese),
-        "persian": Calendar(identifier: .persian),
-        "republicOfChina": Calendar(identifier: .republicOfChina),
-        "islamicTabular": Calendar(identifier: .islamicTabular),
-        "islamicUmmAlQura": Calendar(identifier: .islamicUmmAlQura)
+        "gregorian": Calendar.Identifier.gregorian,
+        "japanese": .japanese,
+        "buddhist": .buddhist,
+        "roc": .republicOfChina,
+        "persian": .persian,
+        "islamic-civil": .islamicCivil,
+        "islamic": .islamic,
+        "hebrew": .hebrew,
+        "chinese": .chinese,
+        "indian": .indian,
+        "coptic": .coptic,
+        "ethiopic": .ethiopicAmeteMihret,
+        "ethiopic-amete-alem": .ethiopicAmeteAlem,
+        "iso8601": .iso8601,
+        "islamic-umalqura": .islamicUmmAlQura,
+        "islamic-tbla": .islamicTabular,
     ]
     
     func boot(routes: RoutesBuilder) throws {
@@ -73,10 +75,11 @@ class FormatAPIController: RouteCollection {
         }
         
         let formatted = formatter.string(from: date)
+        let calendarIDName = calendars.first(where: { $0.value == calendar.identifier })?.key ?? "gregorian"
         
         return FormatResponse(
             id: request.id,
-            calendar: "\(calendar.identifier)",
+            calendar: calendarIDName,
             timeZone: timeZone.identifier,
             locale: locale.identifier,
             timestamp: date.timeIntervalSince1970,
@@ -100,10 +103,10 @@ class FormatAPIController: RouteCollection {
     private func resolveCalendar(matching identifier: String?, fallback: Locale) throws -> Calendar {
         if let identifier {
             let loweredCalID = identifier.lowercased()
-            guard let c = self.calendars.first(where: { $0.key.lowercased() == loweredCalID })?.value else {
+            guard let calendarIdentifier = self.calendars.first(where: { $0.key.lowercased() == loweredCalID })?.value else {
                 throw Abort(.badRequest, reason: "Unknown calendar: '\(identifier)'")
             }
-            return c
+            return Calendar(identifier: calendarIdentifier)
         } else {
             return fallback.calendar
         }

--- a/Sources/App/Controllers/FormatAPIController.swift
+++ b/Sources/App/Controllers/FormatAPIController.swift
@@ -8,18 +8,18 @@ class FormatAPIController: RouteCollection {
         "buddhist": Calendar(identifier: .buddhist),
         "chinese": Calendar(identifier: .chinese),
         "coptic": Calendar(identifier: .coptic),
-        "ethiopicametemihret": Calendar(identifier: .ethiopicAmeteMihret),
-        "ethiopicametealem": Calendar(identifier: .ethiopicAmeteAlem),
+        "ethiopicAmeteMihret": Calendar(identifier: .ethiopicAmeteMihret),
+        "ethiopicAmeteAlem": Calendar(identifier: .ethiopicAmeteAlem),
         "hebrew": Calendar(identifier: .hebrew),
         "iso8601": Calendar(identifier: .iso8601),
         "indian": Calendar(identifier: .indian),
         "islamic": Calendar(identifier: .islamic),
-        "islamiccivil": Calendar(identifier: .islamicCivil),
+        "islamicCivil": Calendar(identifier: .islamicCivil),
         "japanese": Calendar(identifier: .japanese),
         "persian": Calendar(identifier: .persian),
-        "republicofchina": Calendar(identifier: .republicOfChina),
-        "islamictabular": Calendar(identifier: .islamicTabular),
-        "islamicummalqura": Calendar(identifier: .islamicUmmAlQura)
+        "republicOfChina": Calendar(identifier: .republicOfChina),
+        "islamicTabular": Calendar(identifier: .islamicTabular),
+        "islamicUmmAlQura": Calendar(identifier: .islamicUmmAlQura)
     ]
     
     func boot(routes: RoutesBuilder) throws {
@@ -99,7 +99,8 @@ class FormatAPIController: RouteCollection {
     
     private func resolveCalendar(matching identifier: String?, fallback: Locale) throws -> Calendar {
         if let identifier {
-            guard let c = self.calendars[identifier.lowercased()] else {
+            let loweredCalID = identifier.lowercased()
+            guard let c = self.calendars.first(where: { $0.key.lowercased() == loweredCalID })?.value else {
                 throw Abort(.badRequest, reason: "Unknown calendar: '\(identifier)'")
             }
             return c

--- a/Sources/App/Controllers/FormatAPIController.swift
+++ b/Sources/App/Controllers/FormatAPIController.swift
@@ -134,30 +134,32 @@ class FormatAPIController: RouteCollection {
 /// Valid JSON requests can look like:
 ///
 /// ```json
-/// // format the current date in the default locale, calendar, and time zone
-/// { 
-///   "format": { "date": "full" }
-/// }
-///
-/// // format a specific point in time according to a specific locale,
-/// // calendar, and time zone using a template format
-/// {
-///  "locale": "en_US",
-///  "calendar": "japanese",
-///  "timeZone": "africa/addis_ababa",
-///  "timestamp": 1234567890.987,
-///  "format": { "template": "yMMMdHHmmss" }
-/// }
-///
-/// // format a specific point in time using the default locale and calendar,
-/// // but in the New York time zone and using an ISO 8601-like format.
-/// {
-///  "id": "an-id-from-my-app",
-///  "timeZone": "America/New_York",
-///  "timestamp": 1708705211,
-///  "format": { "raw": "y-MM-dd'T'HH:mm:ss.SSSX" }
-/// }
+/// [
+///   {
+///     "format": { "date": "full" }
+///   },
+///   {
+///     "locale": "en_US",
+///     "calendar": "japanese",
+///     "timeZone": "africa/addis_ababa",
+///     "timestamp": 1234567890.987,
+///     "format": { "template": "yMMMdHHmmss" }
+///   },
+///   {
+///     "id": "an-id-from-my-app",
+///     "timeZone": "America/New_York",
+///     "timestamp": 1708705211,
+///     "format": { "raw": "y-MM-dd'T'HH:mm:ss.SSSX" }
+///   }
+/// ]
 /// ```
+///
+/// This example requests three different formattings:
+/// 1. Format the current date in the default, locale, calendar, and time zone
+/// 2. Format a specific point in time according to the specified locale, calendar, and time zone using a template format
+/// 3. Format a specific point in time using the default locale and calendar, in the New York time zone using an ISO 8601-like format.
+///
+/// The response is an array of ``FormatResponse`` values, in the same order as the corresponding requests.
 struct FormatRequest: Content {
     
     /// A client-provided identifier for the request.

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -2,5 +2,6 @@ import Vapor
 
 func routes(_ app: Application) throws {
     try app.register(collection: FormatterController())
+    try app.register(collection: FormatAPIController())
 }
 


### PR DESCRIPTION
This adds two new endpoints to the website:

- `GET /info.json` - returns a simple structure listing supported locales, calendars, time zones, and the tzdb version
- `POST /format.json` - given an array of requests to format timestamps in certain locales, calendars, and/or time zones with varying formats, this returns the formatted strings. The full details of the format are in the commit message.

(This also updates the packages to their latest versions)